### PR TITLE
Fix vim plugin bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All new features, notable changes and fixes of this project are going to be docu
 
 ### Fixes
 
+* The file for a search result containing a backticks command substitution can be opened with the VIM plugin.
+
 ## [Kitty 1.4]
 
 ### New features

--- a/vim/explorer.vim
+++ b/vim/explorer.vim
@@ -1,6 +1,6 @@
 function! KittyGoToSelectedFile()
   let grepResult = getline('.')
-  let bashCommandToGetLineNumberAndPath = "echo ".grepResult." | sed -E 's/(^.*)[:|-]([0-9]+)[:|-].*$/+:\\2 \\1/'"
+  let bashCommandToGetLineNumberAndPath = "echo '".grepResult."' | sed -E 's/(^.*)[:|-]([0-9]+)[:|-].*$/+:\\2 \\1/'"
   let vimCommandToOpenPath = ":tabe ".system(bashCommandToGetLineNumberAndPath)
   execute vimCommandToOpenPath
 endfunction


### PR DESCRIPTION
A search result containing a backticks command substitution made the VIM plugin fail.
Backtick command substitutions are now wrapped in single quotes in order not to be expanded.